### PR TITLE
fix: teach the nixos-module to identify itself

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,8 @@
     nixosModule = { lib, config, ... }: let
       cfg = config.services.hydra.provisioner;
     in {
+      _file = "hydra-provisioner";
+
       imports = [ ./module.nix ];
 
       config = with lib; {


### PR DESCRIPTION
without this key, this is essentially an anonymous
nixos module. In practice that has been worked
around by aliasing it in downstream repos which
is downstream smelly code.